### PR TITLE
Bundle the correct networking module to fix #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 	modCompile "io.github.prospector.modmenu:ModMenu:${project.modmenu_version}"
 
-	include "net.fabricmc.fabric-api:fabric-networking:${project.fabric_networking_version}"
+	include "net.fabricmc.fabric-api:fabric-networking-v0:${project.fabric_networking_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ archives_base_name = Crochet
 
 # Dependencies
 fabric_api_version=0.3.0-pre+build.156
-fabric_networking_version=0.1.0+93af775a
+fabric_networking_version=0.1.0+f1618918
 modmenu_version=1.5.4-85


### PR DESCRIPTION
Fixes mixin apply errors on load when installed alongside the latest fabric API (#3)